### PR TITLE
Init PostgreSQL

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,23 @@
+import * as dotenv from 'dotenv';
 import express from 'express';
+import postgres from 'postgres';
+
+dotenv.config();
 
 const app = express();
 const port = 3000;
 
-app.get('/', (req, res) => {
-  res.send('Hello World!');
+const sql = postgres({
+  host: process.env.DB_HOST,
+  port: process.env.DB_PORT,
+  database: process.env.DB_DATABASE,
+  username: process.env.DB_USERNAME,
+  password: process.env.DB_PASSWORD,
+});
+
+app.get('/', async (req, res) => {
+  const [ {'?column?': one} ] = await sql`select 1;`;
+  res.send(`Hello World! Here's a number from Postgres: ${one}`);
 });
 
 // Start the webserver

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "express": "^4.18.2"
+        "dotenv": "^16.0.3",
+        "express": "^4.18.2",
+        "postgres": "^3.3.3"
       }
     },
     "node_modules/accepts": {
@@ -127,6 +129,14 @@
       "engines": {
         "node": ">= 0.8",
         "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.0.3",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.0.3.tgz",
+      "integrity": "sha512-7GO6HghkA5fYG9TYnNxi14/7K9f5occMlp3zXAuSxn7CKCxt9xbNWG7yF8hTCSUchlfWSe3uLmlPfigevRItzQ==",
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/ee-first": {
@@ -403,6 +413,15 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.7.tgz",
       "integrity": "sha512-5DFkuoqlv1uYQKxy8omFBeJPQcdoE07Kv2sferDCrAq1ohOU+MSDswDIbnx3YAM60qIOnYa53wBhXW0EbMonrQ=="
+    },
+    "node_modules/postgres": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/postgres/-/postgres-3.3.3.tgz",
+      "integrity": "sha512-FGLZOpZSXePRIQu6LJpJUDikzuhplWI80uyyfmKBiljpfO+Z4nuClwpq3/dsRnitxVDsgFN5duJ7eUTaC0meQQ==",
+      "funding": {
+        "type": "individual",
+        "url": "https://github.com/sponsors/porsager"
+      }
     },
     "node_modules/proxy-addr": {
       "version": "2.0.7",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   },
   "homepage": "https://github.com/LumosCapstone/backend#readme",
   "dependencies": {
-    "express": "^4.18.2"
+    "dotenv": "^16.0.3",
+    "express": "^4.18.2",
+    "postgres": "^3.3.3"
   }
 }


### PR DESCRIPTION
The app now connects to a PostgreSQL server and executes a simple `select 1;` statement when `localhost:3000/` is visited. 

This will close #2 

**Changes**
- Add `dotenv` and `postgres` npm packages
- Init dotenv and DB connection in `index.js`
- Update `/` endpoint in `index.js` to return a number from the DB

**How to Test**
- Download and install PostgreSQL 13 if you haven't already. You can get it from homebrew on MacOS or [here](https://www.postgresql.org/download/windows/) on Windows. Make sure the server is running
- Create a `.env` in the root of the project and add the following to it. This file should not be included in version control
```bash
DB_HOST=localhost
DB_PORT=5432
DB_DATABASE=postgres
DB_USERNAME=postgres
DB_PASSWORD=postgres
```
- Start the server with `node .`, visit `localhost:3000/`, verify that the page shows a number from Postgres (see image below)

![Screen Shot 2023-03-01 at 2 55 54 PM](https://user-images.githubusercontent.com/33915719/222285317-f9b33d00-c6f1-4c29-95f6-5bb5250b6903.jpg)
