### PR TITLE
`/api/item` should filter out reserved resources 

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,8 @@ app.get('/api/item', async (req, res) => {
      from resources 
      left outer join users on users.id = owned_by 
      left outer join images on resource_id = resources.id 
-     where ${resources_within_range_sql(point, max_distance, type)}`;
+     where reservation_status = ${ITEM.LISTED} and
+     ${resources_within_range_sql(point, max_distance, type)}`;
 
     // If rows are empty, items do not exist. 
     if (resources.length < 1) {


### PR DESCRIPTION
Fix for #34 

Added condition `reservation_status = ${ITEM.LISTED}` to the `WHERE` clause in order to filter by the correct item status (listed, no active reservations).